### PR TITLE
Guard against environments without extended console

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,15 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "adambom",
+      "name": "Adam Savitzky",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/294597?s=460&v=4",
+      "profile": "https://github.com/adambom",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 const { ApolloLink } = require('apollo-link');
 const formatMessage = require('./formatMessage');
+const logging = require('./logging');
 
 const loggerLink = new ApolloLink((operation, forward) => {
   const startTime = new Date().getTime();
@@ -10,12 +11,12 @@ const loggerLink = new ApolloLink((operation, forward) => {
 
     const group = formatMessage(operationType, operation, ellapsed);
 
-    console.groupCollapsed(...group);
+    logging.groupCollapsed(...group);
 
-    console.log('INIT', operation);
-    console.log('RESULT', result);
+    logging.log('INIT', operation);
+    logging.log('RESULT', result);
 
-    console.groupEnd(...group);
+    logging.groupEnd(...group);
     return result;
   });
 });

--- a/src/logging.js
+++ b/src/logging.js
@@ -1,0 +1,30 @@
+const logging = (() => {
+  let prefix = '';
+
+  const consoleLog = (...args) => {
+    console.log(prefix, ...args);
+  };
+
+  const consoleError = (...args) => {
+    console.error(prefix, ...args);
+  };
+
+  const consoleGroup = (...args) => {
+    consoleLog(...args);
+    prefix += '> ';
+  };
+
+  const consoleGroupEnd = () => {
+    prefix = prefix.slice(0, -2);
+  };
+
+  return {
+    log: consoleLog,
+    error: consoleError,
+    group: console.group || consoleGroup,
+    groupCollapsed: console.groupCollapsed || consoleGroup,
+    groupEnd: console.groupEnd || consoleGroupEnd,
+  };
+})();
+
+module.exports = logging;


### PR DESCRIPTION
Fixes #1

Extended console methods like `console.groupCollapsed` and `console.groupEnd` are not available in the react-native node runtime, unless the chrome debugger is open, since the runtime is replaced with V8. This means that using `apolloLogger` will cause uncaught network errors in the link stack when it tries to call these functions.

This change neutralizes that threat by just assigning functions that will noop if the `console` functions are not available.