### PR TITLE
fix: message for subscription

### DIFF
--- a/src/__tests__/__snapshots__/formatMessage.test.js.snap
+++ b/src/__tests__/__snapshots__/formatMessage.test.js.snap
@@ -6,7 +6,6 @@ Array [
   "color: gray; font-weight: lighter",
   "color: red;",
   "color: inherit;",
-  "color: gray; font-weight: lighter;",
 ]
 `;
 

--- a/src/formatMessage.js
+++ b/src/formatMessage.js
@@ -3,16 +3,17 @@ const formatMessage = (operationType, operation, ellapsed) => {
     'color: gray; font-weight: lighter', // title
     `color: ${operationType === 'query' ? '#03A9F4' : 'red'};`, // operationType
     'color: inherit;', // operationName
-    'color: gray; font-weight: lighter;', // time, etc
   ];
 
-  const parts = ['%c apollo'];
-
-  parts.push(`%c${operationType}`);
-  parts.push(`%c${operation.operationName}`);
+  const parts = [
+    '%c apollo',
+    `%c${operationType}`,
+    `%c${operation.operationName}`,
+  ];
 
   if (operationType !== 'subscription') {
     parts.push(`%c(in ${ellapsed} ms)`);
+    headerCss.push('color: gray; font-weight: lighter;'); // time
   }
 
   return [parts.join(' '), ...headerCss];


### PR DESCRIPTION
<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Styles are written in plain text if operation name is subscription. Example: "apollo subscription Subscription color: gray; font-weight: lighter;"

<!-- Why are these changes necessary? -->

**Why**: Because for subscription operation name formatMessage return: ["%c apollo %csubscription %Subscription", "color: gray; font-weight: lighter", "color: red;", "color: inherit", "color: gray; font-weight: lighter;"]

<!-- How were these changes implemented? -->

**How**: Fix formatMessage function. For subscription operation name formatMessage must return: ["%c apollo %csubscription %Subscription", "color: gray; font-weight: lighter", "color: red;", "color: inherit"]

<!-- Have you done all of these things?  -->

**Checklist**:
- fix formatMessage function

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

* [x] Documentation
* [x] Tests
* [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
* [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
